### PR TITLE
Fix #882: Cloned gates don't fail if the source step is invalid.

### DIFF
--- a/comp-control/src/main/java/org/jumpmind/metl/core/runtime/component/Gate.java
+++ b/comp-control/src/main/java/org/jumpmind/metl/core/runtime/component/Gate.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.jumpmind.metl.core.model.FlowStepLink;
 import org.jumpmind.metl.core.runtime.ControlMessage;
 import org.jumpmind.metl.core.runtime.Message;
 import org.jumpmind.metl.core.runtime.flow.ISendMessageCallback;
@@ -56,7 +57,13 @@ public class Gate extends AbstractComponentRuntime {
         gateControlSourceStepId = typedProperties.get(SOURCE_STEP); 
         forceGateOpen = typedProperties.is(SETTING_FORCE_GATE_OPEN, forceGateOpen);
         
-        if (isBlank(gateControlSourceStepId) || getFlow().findFlowStepWithId(gateControlSourceStepId) == null) {
+        if (isBlank(gateControlSourceStepId) 
+        		|| getFlow().findFlowStepWithId(gateControlSourceStepId) == null
+        		// A bad control source can be cloned from another gate. 
+        		// Validate that the source step is valid on this step.
+        		|| getFlow().getFlowStepLinks().stream()
+        			.noneMatch(s -> s.getSourceStepId().equals(gateControlSourceStepId) 
+        					&& s.getTargetStepId().equals(this.getFlowStepId()))) {
             throw new IllegalStateException("The gate control source must be specified");
         }
     }


### PR DESCRIPTION
Added validation step to make sure the control source step id is a valid source step. The source id can be invalid if we cloned a gate, and the source step id is not valid for the resulting clone.