### PR TITLE
AWS SQS Credential Enhancements

### DIFF
--- a/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
+++ b/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
@@ -23,6 +23,7 @@ package org.jumpmind.metl.core.runtime.component;
 import java.util.ArrayList;
 
 import org.jumpmind.metl.core.runtime.ControlMessage;
+import org.jumpmind.metl.core.runtime.LogLevel;
 import org.jumpmind.metl.core.runtime.Message;
 import org.jumpmind.metl.core.runtime.MisconfiguredException;
 import org.jumpmind.metl.core.runtime.flow.ISendMessageCallback;
@@ -125,7 +126,7 @@ public class SQSReader extends AbstractComponentRuntime {
             try {
                 client.deleteMessage(request);
             } catch (Exception e) {
-                throw new RuntimeException("Could not delete message from SQS queue: " + e.getMessage());
+                log(LogLevel.WARN, "Failed to delete SQS message: %s", message);
             }
 
         }

--- a/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
+++ b/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
@@ -100,7 +100,12 @@ public class SQSReader extends AbstractComponentRuntime {
                 .maxNumberOfMessages(maxMsgsToReadAtOnce)
                 .build();
 
-        ReceiveMessageResponse response = client.receiveMessage(request);
+        ReceiveMessageResponse response = null;
+        try {
+            response = client.receiveMessage(request);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not receive message from SQS queue: " + e.getMessage());
+        }
 
         response.messages().forEach(message -> {
             messages.add(message.body());
@@ -117,7 +122,12 @@ public class SQSReader extends AbstractComponentRuntime {
                     .receiptHandle(message.receiptHandle())
                     .build();
 
-            client.deleteMessage(request);
+            try {
+                client.deleteMessage(request);
+            } catch (Exception e) {
+                throw new RuntimeException("Could not delete message from SQS queue: " + e.getMessage());
+            }
+
         }
     }
     private ArrayList<String> consolidateMessages(ArrayList<String> messages) {

--- a/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/SQSQueue.java
+++ b/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/SQSQueue.java
@@ -1,50 +1,78 @@
 package org.jumpmind.metl.core.runtime.resource;
 
 import org.jumpmind.metl.core.model.Resource;
+import org.jumpmind.metl.core.runtime.MisconfiguredException;
 import org.jumpmind.properties.TypedProperties;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
 public class SQSQueue extends AbstractResourceRuntime {
-	
-	public final static String TYPE = "SQSQueue";
 
-	public static final String SETTING_ACCESS_KEY = "access.key";
+    public final static String TYPE = "SQSQueue";
 
-	public static final String SETTING_SECRET_ACCESS_KEY = "secret.access.key";
-	
-	public static final String SETTING_REGION = "region";
-	
+    public static final String SETTING_CREDENTIAL_TYPE = "credential.type";
+
+    public static final String SETTING_ACCESS_KEY = "access.key";
+
+    public static final String SETTING_SECRET_ACCESS_KEY = "secret.access.key";
+
+    public static final String SETTING_REGION = "region";
+
+    private String credentialType;
+    private String accessKey;
+    private String secretAccessKey;
+    private String region;
+
     SqsClient sqsClient;
-    
-	@SuppressWarnings("unchecked")
-	@Override
-	public <T> T reference() {
-		return (T) sqsClient;
-	}
 
-	public void start(Resource resource, TypedProperties resourceRuntimeSettings) {
-		if (resourceRuntimeSettings.get(SETTING_ACCESS_KEY) != null &&
-		        resourceRuntimeSettings.get(SETTING_SECRET_ACCESS_KEY) != null)  {
-			Thread.currentThread().setContextClassLoader(null);
-			sqsClient = createSqsClient(resourceRuntimeSettings);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T reference() {
+        return (T) sqsClient;
+        }
 
-	private SqsClient createSqsClient(TypedProperties settings) {
-		AwsCredentials credentials = AwsBasicCredentials.create(settings.get(SETTING_ACCESS_KEY),
-				settings.get(SETTING_SECRET_ACCESS_KEY));
-		return SqsClient.builder().region(Region.of(settings.get(SETTING_REGION)))
-				.credentialsProvider(StaticCredentialsProvider.create(credentials)).build();
-	}	
+    public void start(Resource resource, TypedProperties resourceRuntimeSettings) {
+        credentialType = resourceRuntimeSettings.get(SETTING_CREDENTIAL_TYPE);
+        accessKey = resourceRuntimeSettings.get(SETTING_ACCESS_KEY);
+        secretAccessKey = resourceRuntimeSettings.get(SETTING_SECRET_ACCESS_KEY);
+        region = resourceRuntimeSettings.get(SETTING_REGION);
 
-	@Override
-	public void stop() {
-		sqsClient.close();
-	}
+        if (credentialType.equals("AWS SDK") && (accessKey == null || secretAccessKey == null)) {
+            throw new MisconfiguredException("Access Key and Secret Access Key are required for Credential Type AWS SDK");
+        }
+
+        Thread.currentThread().setContextClassLoader(null);
+        sqsClient = createSqsClient();
+    }
+
+    private SqsClient createSqsClient() {
+        try {
+            if (accessKey == null && secretAccessKey == null) {
+               return SqsClient.builder()
+                       .region(Region.of(region))
+                       .build();
+            }
+
+            AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretAccessKey);
+            AwsCredentialsProvider provider = StaticCredentialsProvider.create(credentials);
+
+            return SqsClient.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(provider)
+                    .build();
+        } catch (Exception e) {
+           throw new RuntimeException("Could not create SQS Client: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void stop() {
+        sqsClient.close();
+    }
 
 }

--- a/resource-core/src/main/resources/plugin.xml
+++ b/resource-core/src/main/resources/plugin.xml
@@ -554,7 +554,7 @@
                 <defaultValue>none</defaultValue>
                 <choices>
                     <choice>AWS SDK</choice>
-                    <choice>System Environment Variables</choice>
+                    <choice>System</choice>
                 </choices>
             </setting>
             <setting id='access.key' type='text'>

--- a/resource-core/src/main/resources/plugin.xml
+++ b/resource-core/src/main/resources/plugin.xml
@@ -549,11 +549,19 @@
         <name>SQS Queue</name>
         <className>org.jumpmind.metl.core.runtime.resource.SQSQueue</className>
         <settings>
-            <setting id='access.key' required='true' type='text'>
-                <name>Access Key</name>
+            <setting id='credential.type' required='true' type='choice'>
+                <name>Credential Type</name>
+                <defaultValue>none</defaultValue>
+                <choices>
+                    <choice>AWS SDK</choice>
+                    <choice>System Environment Variables</choice>
+                </choices>
             </setting>
-            <setting id='secret.access.key' required='true' type='text'>
-                <name>Secret Access Key</name>
+            <setting id='access.key' type='text'>
+                <name>Access Key (Required for AWS SDK credential type)</name>
+            </setting>
+            <setting id='secret.access.key' type='text'>
+                <name>Secret Access Key (Required for AWS SDK credential type)</name>
             </setting>
             <setting id='region' required='true' type='choice'>
                 <name>Region</name>


### PR DESCRIPTION
- Allow users to select credential type for SQS Queue resource:
    - 'AWS SDK'
        - Take the credentials provided in the METL resource and use them via a credential provider when creating the SQSClient instance
    - 'System' will look at: 
        - 1) System Environment Variables
        - 2) `~/.aws/` directory properly following AWS configuration guidelines
        - 3) IAM role credentials

More info here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence