### PR TITLE
Feature/sqs deletes

### DIFF
--- a/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSDelete.java
+++ b/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSDelete.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to JumpMind Inc under one or more contributor
+ * license agreements.  See the NOTICE file distributed
+ * with this work for additional information regarding
+ * copyright ownership.  JumpMind Inc licenses this file
+ * to you under the GNU General Public License, version 3.0 (GPLv3)
+ * (the "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * version 3.0 (GPLv3) along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jumpmind.metl.core.runtime.component;
+
+import org.jumpmind.metl.core.runtime.ControlMessage;
+import org.jumpmind.metl.core.runtime.Message;
+import org.jumpmind.metl.core.runtime.flow.ISendMessageCallback;
+import org.jumpmind.properties.TypedProperties;
+
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+
+public class SQSDelete extends AbstractComponentRuntime {
+
+    public final static String TYPE = "SQS Delete";
+    
+    public final static String SQS_MESSAGE_HEADER_KEY = "sqsMessageReceipt";
+
+    public final static String SQS_DELETE_QUEUE_URL = "sqs.delete.queue.url";
+
+    /* settings */
+    String queueUrl;
+    String runWhen;
+
+    @Override
+    public void start() {
+        if (getResourceRuntime() == null) {
+            throw new IllegalStateException("SQS queue resource must be defined");
+        }
+
+        TypedProperties properties = getTypedProperties();
+        queueUrl = properties.get(SQS_DELETE_QUEUE_URL);
+        runWhen = properties.get(RUN_WHEN);
+    }
+
+    @Override
+    public boolean supportsStartupMessages() {
+        return true;
+    }
+
+    @Override
+    public void handle(Message inputMessage, ISendMessageCallback callback, boolean unitOfWorkBoundaryReached) {
+        if (PER_MESSAGE.equals(runWhen) && (!(inputMessage instanceof ControlMessage) || context.isStartStep())
+                || (PER_UNIT_OF_WORK.equals(runWhen) && inputMessage instanceof ControlMessage)) {
+
+            SqsClient client = (SqsClient)getResourceReference();
+
+            String receiptHandle = inputMessage.getHeader().get(SQS_MESSAGE_HEADER_KEY).toString();
+            DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(receiptHandle)
+                    .build();
+
+            client.deleteMessage(deleteMessageRequest);
+        }
+    }
+}

--- a/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
+++ b/comp-sqs/src/main/java/org/jumpmind/metl/core/runtime/component/SQSReader.java
@@ -114,7 +114,7 @@ public class SQSReader extends AbstractComponentRuntime {
             String messageBody = "";
 
             for (software.amazon.awssdk.services.sqs.model.Message message : response.messages()) {
-                deleteMessage(client, message);
+                deleteMessage(client, message.receiptHandle());
                 messageBody = message.body();
             }
 
@@ -124,17 +124,17 @@ public class SQSReader extends AbstractComponentRuntime {
         }
     }
 
-    private void deleteMessage(SqsClient client, software.amazon.awssdk.services.sqs.model.Message message) {
+    private void deleteMessage(SqsClient client, String messageReceipt) {
         if (deleteWhen.equals("AFTER EVERY READ")) {
             DeleteMessageRequest request = DeleteMessageRequest.builder()
                     .queueUrl(queueUrl)
-                    .receiptHandle(message.receiptHandle())
+                    .receiptHandle(messageReceipt)
                     .build();
 
             try {
                 client.deleteMessage(request);
             } catch (Exception e) {
-                log(LogLevel.WARN, "Failed to delete SQS message: %s", message);
+                log(LogLevel.WARN, "Failed to delete SQS message with receipt: %s", messageReceipt);
             }
         }
     }

--- a/comp-sqs/src/main/resources/plugin.xml
+++ b/comp-sqs/src/main/resources/plugin.xml
@@ -66,19 +66,13 @@
         <name>Max Messages to Read</name>
         <defaultValue>1</defaultValue>
       </setting>
-      <setting id='sqs.reader.queue.messages.per.output.message'
-               required='true'
-               type='integer'>
-        <name>Queue Messages Per OutputMessage</name>
-        <defaultValue>1</defaultValue>
-      </setting>
       <setting id='sqs.reader.delete.when'
                required='true'
                type='choice'>
         <name>Delete When</name>
-        <defaultValue>AFTER EVERY READ</defaultValue>
+        <defaultValue>ON READ</defaultValue>
         <choices>
-          <choice>AFTER EVERY READ</choice>
+          <choice>ON READ</choice>
           <choice>ON FLOW COMPLETION</choice>
           <choice>DO NOT DELETE</choice>
         </choices>

--- a/comp-sqs/src/main/resources/plugin.xml
+++ b/comp-sqs/src/main/resources/plugin.xml
@@ -60,10 +60,10 @@
                type='text'>
         <name>Queue URL</name>
       </setting>
-      <setting id='sqs.reader.max.messages.read.at.once'
+      <setting id='sqs.reader.max.messages.to.read'
                required='true'
                type='integer'>
-        <name>Max Messages to Read at Once</name>
+        <name>Max Messages to Read</name>
         <defaultValue>1</defaultValue>
       </setting>
       <setting id='sqs.reader.queue.messages.per.output.message'
@@ -72,11 +72,16 @@
         <name>Queue Messages Per OutputMessage</name>
         <defaultValue>1</defaultValue>
       </setting>
-      <setting id='sqs.reader.delete.after.read'
+      <setting id='sqs.reader.delete'
                required='true'
-               type='boolean'>
-        <name>Delete Messages After Read</name>
-        <defaultValue>false</defaultValue>
+               type='choice'>
+        <name>Delete</name>
+        <defaultValue>AFTER EVERY READ</defaultValue>
+        <choices>
+          <choice>AFTER EVERY READ</choice>
+          <choice>ON FLOW COMPLETION</choice>
+          <choice>DO NOT DELETE</choice>
+        </choices>
       </setting>
       <setting id='sqs.reader.read.until.queue.empty'
                required='true'

--- a/comp-sqs/src/main/resources/plugin.xml
+++ b/comp-sqs/src/main/resources/plugin.xml
@@ -72,10 +72,10 @@
         <name>Queue Messages Per OutputMessage</name>
         <defaultValue>1</defaultValue>
       </setting>
-      <setting id='sqs.reader.delete'
+      <setting id='sqs.reader.delete.when'
                required='true'
                type='choice'>
-        <name>Delete</name>
+        <name>Delete When</name>
         <defaultValue>AFTER EVERY READ</defaultValue>
         <choices>
           <choice>AFTER EVERY READ</choice>

--- a/comp-sqs/src/main/resources/plugin.xml
+++ b/comp-sqs/src/main/resources/plugin.xml
@@ -100,5 +100,33 @@
         </choices>
       </setting>
     </settings>
-  </component>  
+  </component>
+    <component category='PROCESSOR'
+             id='SQS Delete'
+             inputMessageType='any'
+             inputOutputModelsMatch='false'
+             outputMessageType='text'
+             resourceCategory='queue'>
+    <name>SQS Delete</name>
+    <className>org.jumpmind.metl.core.runtime.component.SQSDelete</className>
+    <keywords>sqs,delete</keywords>
+    <description></description>
+    <settings>
+      <setting id='run.when'
+               required='false'
+               type='choice'>
+        <name>Run When</name>
+        <defaultValue>PER UNIT OF WORK</defaultValue>
+        <choices>
+          <choice>PER UNIT OF WORK</choice>
+          <choice>PER MESSAGE</choice>
+        </choices>
+      </setting>
+      <setting id='sqs.delete.queue.url'
+               required='true'
+               type='text'>
+        <name>Queue URL</name>
+      </setting>
+    </settings>
+  </component>
 </definitions>

--- a/comp-sqs/src/main/resources/ui.xml
+++ b/comp-sqs/src/main/resources/ui.xml
@@ -26,5 +26,8 @@
     </component-ui>
     <component-ui id="SQS Writer UI" componentId="SQS Writer">
         <iconImage>org/jumpmind/metl/core/runtime/component/sqs-48x48-color.png</iconImage>
-    </component-ui>    
+    </component-ui>
+    <component-ui id="SQS Delete UI" componentId="SQS Delete">
+        <iconImage>org/jumpmind/metl/core/runtime/component/sqs-48x48-color.png</iconImage>
+    </component-ui>
 </ui>


### PR DESCRIPTION
Rework the Delete functionality for SQS reader component. SQS Reader now has options to delete messages when:
- After every read the message will be delete
- When the flow completes, all messages read will be deleted
- Never delete messages

An SQS Delete component has been added that will read an SQS message receipt from the METL message header and delete it.