### PR TITLE
Mapping component bug fix

### DIFF
--- a/metl-core/src/main/java/org/jumpmind/metl/core/model/DeploymentStatus.java
+++ b/metl-core/src/main/java/org/jumpmind/metl/core/model/DeploymentStatus.java
@@ -21,7 +21,7 @@
 package org.jumpmind.metl.core.model;
 
 public enum DeploymentStatus {
-    ENABLED("Enabled"), DISABLED("Disabled"), REQUEST_ENABLE("Enabling"), REQUEST_REMOVE("Removing"), REQUEST_DISABLE("Disabling"), REQUEST_REENABLE("Renabling"), ERROR("Error");
+    ENABLED("Enabled"), DISABLED("Disabled"), REQUEST_ENABLE("Enabling"), REQUEST_REMOVE("Removing"), REQUEST_DISABLE("Disabling"), REQUEST_REENABLE("Re-enabling"), ERROR("Error");
     
     String name;
     

--- a/metl-core/src/main/java/org/jumpmind/metl/core/persist/ImportExportService.java
+++ b/metl-core/src/main/java/org/jumpmind/metl/core/persist/ImportExportService.java
@@ -468,6 +468,8 @@ public class ImportExportService extends AbstractService implements IImportExpor
                 transaction);
         processTableDeletes(importData.deletesToProcess.get(tablePrefix + "_component_entity_setting"),
                 transaction);
+        processTableDeletes(importData.deletesToProcess.get(tablePrefix + "_component_model_setting"),
+                transaction);
         processTableDeletes(importData.deletesToProcess.get(tablePrefix + "_component_setting"),
                 transaction);
         processTableDeletes(importData.deletesToProcess.get(tablePrefix + "_component"),


### PR DESCRIPTION
This change fixes a bug when importing the Mapping component. 

Steps to reproduce the bug:
- In environment A, create a flow with a mapping component and assign any number of fields mapped from Input model -> Output model
- Export the flow from environment A
- Import the flow into environment B
- In environment A, change the mapping lines in any way
- Export the flow again from environment A
- Import the flow again into environment B
- Bug: The mappings from the first export will persist after the import.

This bug was being caused by the existing `METL_component_model_setting` records not being cleaned up after the import.
Also fixed a typo.