### PR TITLE
refactored start()/reference() to work around class loader issue

### DIFF
--- a/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/aws/S3.java
+++ b/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/aws/S3.java
@@ -1,5 +1,7 @@
 package org.jumpmind.metl.core.runtime.resource.aws;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jumpmind.metl.core.runtime.resource.AbstractResourceRuntime;
@@ -13,9 +15,7 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 
 public class S3 extends AbstractResourceRuntime {
     public static final class Settings {
-
-        public final static String TYPE = "AWS S3";
-        
+        /** Name of the setting that identifies the AWS S3 region. */
         public static final String REGION = "aws.s3.region";
 
         public static final String USE_REGION_AS_CRYPTO_DEFAULT = "aws.s3.region.as.crypto.default";
@@ -27,95 +27,65 @@ public class S3 extends AbstractResourceRuntime {
         }
     }
 
-    private final AtomicReference<S3AsyncClient> clientReference = new AtomicReference<>();
-
-    private final AtomicReference<ClientSideCrypto> cseReference = new AtomicReference<>();
-
-    private final AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain
-            .of(DefaultCredentialsProvider.builder().build());
-
-    private String regionId;
-
-    private Region region;
-
-    private String bucketName;
-
-    private boolean clientSideCrypto;
-
-    private String listFilesDelimiter = S3Directory.Settings.DEFAULT_LIST_FILES_DELIMITER;
-
-    private int transferWindowSize = S3Directory.Settings.DEFAULT_TRANSFER_WINDOW_SIZE;
-
-    private String restrictModeName;
-
-    private String cmkSpec;
-
-    private boolean useRegionAsCryptoDefault;
-
-    private String defaultRegion;
+    private AtomicReference<IS3BucketOperations> bucketOpsReference = new AtomicReference<>();
 
     @SuppressWarnings("unchecked")
     @Override
     public <T> T reference() {
-        clientReference.set(S3AsyncClient.builder().region(region)
-                .credentialsProvider(credentialsProvider).build());
-
-        if (clientSideCrypto) {
-            cseReference.set(createClientSideCrypto());
-        }
-        
-        return (T) new S3Directory(getResource(), region, bucketName, clientReference.get(),
-                cseReference.get(), listFilesDelimiter, transferWindowSize);
+        return (T) bucketOpsReference.get();
     }
 
     @Override
     protected void start(final TypedProperties properties) {
         super.start(properties);
-        retrieveSettings(properties);
-        retrieveClientSideCryptoSettings(properties);
-    }
 
-    private void retrieveSettings(final TypedProperties properties) {
-        regionId = properties.get(S3.Settings.REGION);
-        if (regionId != null && !regionId.isEmpty()) {
-            region = (regionId != null) ? Region.of(regionId) : null;
+        String regionId = properties.get(S3.Settings.REGION);
+        Region region = (regionId != null) ? Region.of(regionId) : null;
+
+        String bucketName = properties.get(S3.Settings.BUCKET_NAME);
+
+        AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain
+                .of(DefaultCredentialsProvider.builder().build());
+
+        S3AsyncClient client = S3AsyncClient.builder().region(region)
+                .credentialsProvider(credentialsProvider).build();
+
+        ClientSideCrypto cse = null;
+        if (properties.is(ClientSideCrypto.Settings.ENABLED, false)) {
+            cse = createClientSideCrypto(properties, regionId);
         }
 
-        bucketName = properties.get(S3.Settings.BUCKET_NAME);
-        clientSideCrypto = properties.is(ClientSideCrypto.Settings.ENABLED, false);
-
-        listFilesDelimiter = properties.get(S3Directory.Settings.LIST_FILES_DELIMITER,
+        String listFilesDelimiter = properties.get(S3Directory.Settings.LIST_FILES_DELIMITER,
                 S3Directory.Settings.DEFAULT_LIST_FILES_DELIMITER);
-        transferWindowSize = properties.getInt(S3Directory.Settings.TRANSFER_WINDOW_SIZE,
+        int transferWindowSize = properties.getInt(S3Directory.Settings.TRANSFER_WINDOW_SIZE,
                 S3Directory.Settings.DEFAULT_TRANSFER_WINDOW_SIZE);
-    }
-    
-    private void retrieveClientSideCryptoSettings(final TypedProperties properties) {
-        String defaultRestrictModeName = ClientSideCrypto.RestrictMode.ENCRYPT_DECRYPT.name();
-        restrictModeName = properties.get(ClientSideCrypto.Settings.RESTRICT_MODE, defaultRestrictModeName);
-        cmkSpec = properties.get(ClientSideCrypto.Settings.KMS_CMK_SPEC);
-        useRegionAsCryptoDefault = properties.is(S3.Settings.USE_REGION_AS_CRYPTO_DEFAULT, false);
-        defaultRegion = properties.get(ClientSideCrypto.Settings.DEFAULT_REGION);
+
+        bucketOpsReference.set(new S3Directory(getResource(), region, bucketName, client, cse,
+                listFilesDelimiter, transferWindowSize));
     }
 
-    private ClientSideCrypto createClientSideCrypto() {
-        ClientSideCrypto.RestrictMode restrictMode = ClientSideCrypto.RestrictMode.valueOf(restrictModeName);
-        String regionToUse = useRegionAsCryptoDefault ? regionId : defaultRegion;
-        return ClientSideCrypto.forRestrictMode(restrictMode, cmkSpec, regionToUse);
+    private ClientSideCrypto createClientSideCrypto(final TypedProperties properties,
+            final String s3Region) {
+        String defaultRestrictModeName = ClientSideCrypto.RestrictMode.ENCRYPT_DECRYPT.name();
+        String restrictModeName = properties.get(ClientSideCrypto.Settings.RESTRICT_MODE,
+                defaultRestrictModeName);
+        ClientSideCrypto.RestrictMode restrictMode = ClientSideCrypto.RestrictMode
+                .valueOf(restrictModeName);
+
+        String cmkSpec = properties.get(ClientSideCrypto.Settings.KMS_CMK_SPEC);
+
+        String defaultRegion = properties.is(S3.Settings.USE_REGION_AS_CRYPTO_DEFAULT, false)
+                ? s3Region
+                : properties.get(ClientSideCrypto.Settings.DEFAULT_REGION);
+
+        return ClientSideCrypto.forRestrictMode(restrictMode, cmkSpec, defaultRegion);
     }
 
     @Override
     public void stop() {
-        region = null;
-        bucketName = null;
-        listFilesDelimiter = S3Directory.Settings.DEFAULT_LIST_FILES_DELIMITER;
-        transferWindowSize = S3Directory.Settings.DEFAULT_TRANSFER_WINDOW_SIZE;
-
-        cseReference.set(null);
-
-        S3AsyncClient client = clientReference.getAndSet(null);
-        if (client != null) {
-            client.close();
+        IS3BucketOperations bucketOps = bucketOpsReference.getAndSet(null);
+        if (bucketOps != null) {
+            bucketOps.close();
         }
 
         super.stop();
@@ -134,6 +104,7 @@ public class S3 extends AbstractResourceRuntime {
     public boolean test() {
         try {
             start(getResourceRuntimeSettings());
+            requireNonNull((IS3BucketOperations) reference(), "reference");
             return true;
         } catch (Exception ex) {
             log.warn("test was unsuccessful: %s", ex.toString());


### PR DESCRIPTION
Moving the class reference of S3Directory into the start() method (from reference()) should resolve the class loader problem.