### PR TITLE
move IS3BucketOperations into metl-core (same location as IDirectory)

### DIFF
--- a/comp-file/src/main/java/org/jumpmind/metl/core/runtime/component/S3FileUtil.java
+++ b/comp-file/src/main/java/org/jumpmind/metl/core/runtime/component/S3FileUtil.java
@@ -15,7 +15,7 @@ import org.jumpmind.metl.core.runtime.ControlMessage;
 import org.jumpmind.metl.core.runtime.Message;
 import org.jumpmind.metl.core.runtime.TextMessage;
 import org.jumpmind.metl.core.runtime.flow.ISendMessageCallback;
-import org.jumpmind.metl.core.runtime.resource.aws.IS3BucketOperations;
+import org.jumpmind.metl.core.runtime.resource.IS3BucketOperations;
 import org.jumpmind.properties.TypedProperties;
 
 import software.amazon.awssdk.http.SdkHttpResponse;

--- a/metl-core/src/main/java/org/jumpmind/metl/core/runtime/resource/IS3BucketOperations.java
+++ b/metl-core/src/main/java/org/jumpmind/metl/core/runtime/resource/IS3BucketOperations.java
@@ -1,9 +1,7 @@
-package org.jumpmind.metl.core.runtime.resource.aws;
+package org.jumpmind.metl.core.runtime.resource;
 
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
-
-import org.jumpmind.metl.core.runtime.resource.IDirectory;
 
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.regions.Region;

--- a/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/aws/S3Directory.java
+++ b/resource-core/src/main/java/org/jumpmind/metl/core/runtime/resource/aws/S3Directory.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.jumpmind.metl.core.model.Resource;
 import org.jumpmind.metl.core.runtime.resource.FileInfo;
 import org.jumpmind.metl.core.runtime.resource.IDirectory;
+import org.jumpmind.metl.core.runtime.resource.IS3BucketOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/resource-core/src/test/java/org/jumpmind/metl/core/runtime/resource/aws/S3DirectoryITest.java
+++ b/resource-core/src/test/java/org/jumpmind/metl/core/runtime/resource/aws/S3DirectoryITest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.jumpmind.metl.core.runtime.resource.IS3BucketOperations;
 import org.junit.Test;
 
 import software.amazon.awssdk.core.ResponseBytes;


### PR DESCRIPTION
Noticed that IDirectory (IS3BucketOperations' parent class) is actually loaded from metl-core, **not** resource-core.