### PR TITLE
Fix Action On Error

### DIFF
--- a/metl-core/src/main/java/org/jumpmind/metl/core/runtime/flow/StepRuntime.java
+++ b/metl-core/src/main/java/org/jumpmind/metl/core/runtime/flow/StepRuntime.java
@@ -602,13 +602,11 @@ public class StepRuntime implements Runnable {
     }
 
     private void flowCompletedWithErrors(IComponentRuntime componentRuntime, Throwable myError, List<Throwable> allErrors) {
-        if (!cancelled) {
-            try {
-                componentRuntime.flowCompletedWithErrors(myError);
-            } catch (Throwable ex) {
-                recordError(1, ex);
-                componentContext.getExecutionTracker().flowStepFailedOnComplete(componentContext, ex);
-            }
+        try {
+            componentRuntime.flowCompletedWithErrors(myError);
+        } catch (Throwable ex) {
+            recordError(1, ex);
+            componentContext.getExecutionTracker().flowStepFailedOnComplete(componentContext, ex);
         }
     }
 


### PR DESCRIPTION
Action On Error was not triggered on an error due to all steps canceled.  
When an error occurs it sets all steps as canceled but the FlowCompletedWithErrors method checks if the component wasn't canceled then execute the action in that property however since the error activity set everything canceled, none of the Action on Error properties are executed.  There should never be a time when you cancel at the same time an error occurs so there is no need to check for cancel in this error method.